### PR TITLE
MONARK id for camera commands

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -399,13 +399,15 @@ QGCCameraManager::_requestCameraInfo(int compID, int tryCount)
                 compID,                                 // target component
                 MAV_CMD_REQUEST_MESSAGE,                // command id
                 false,                                  // showError
-                MAVLINK_MSG_ID_CAMERA_INFORMATION);     // msgid
+                MAVLINK_MSG_ID_CAMERA_INFORMATION,      // msgid
+                72);                                    // MONARK ID   
         } else {
             _vehicle->sendMavCommand(
                 compID,                                 // target component
                 MAV_CMD_REQUEST_CAMERA_INFORMATION,     // command id
                 false,                                  // showError
-                1);                                     // Do Request
+                1,                                      // Do Request
+                72);                                    // MONARK ID  
         }
     }
 }


### PR DESCRIPTION
Allows monark_proxy app to know whether to enable the rtp or mpegts gcs stream.