### PR TITLE
FLOWHOLD

### DIFF
--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -59,7 +59,7 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
         APMCopterMode(APMCopterMode::STABILIZE,     false),
         APMCopterMode(APMCopterMode::ACRO,          false),
         APMCopterMode(APMCopterMode::ALT_HOLD,      true),
-        APMCopterMode(APMCopterMode::AUTO,          true),
+        APMCopterMode(APMCopterMode::AUTO,          false),
         APMCopterMode(APMCopterMode::GUIDED,        true),
         APMCopterMode(APMCopterMode::LOITER,        true),
         APMCopterMode(APMCopterMode::RTL,           true),
@@ -75,14 +75,14 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
         APMCopterMode(APMCopterMode::AVOID_ADSB,    false),
         APMCopterMode(APMCopterMode::GUIDED_NOGPS,  false),
         APMCopterMode(APMCopterMode::SMART_RTL,     false),
-        APMCopterMode(APMCopterMode::FLOWHOLD,      false),
+        APMCopterMode(APMCopterMode::FLOWHOLD,      true),
         APMCopterMode(APMCopterMode::FOLLOW,        false),
         APMCopterMode(APMCopterMode::ZIGZAG,        false),
         APMCopterMode(APMCopterMode::SYSTEMID,      false),
         APMCopterMode(APMCopterMode::AUTOROTATE,    false),
         APMCopterMode(APMCopterMode::AUTO_RTL,      true),
         APMCopterMode(APMCopterMode::TURTLE,        false),
-        APMCopterMode(APMCopterMode::OPTICAL_FLOW,        true),
+        APMCopterMode(APMCopterMode::OPTICAL_FLOW,  false),
     });
 
     if (!_remapParamNameIntialized) {

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -42,14 +42,14 @@ public:
         AVOID_ADSB  = 19,
         GUIDED_NOGPS= 20,
         SMART_RTL   = 21,  // SMART_RTL returns to home by retracing its steps
-        FLOWHOLD    = 99,  // This truly points to EchoMAV "Optical Flow" mode and not stock "FLOWHOLD" mode
+        FLOWHOLD    = 22,  // This truly points to custom "OPTICAL_FLOW" in EchoMAV ArduPilot
         FOLLOW      = 23,  // follow attempts to follow another vehicle or ground station
         ZIGZAG      = 24,  // ZIGZAG mode is able to fly in a zigzag manner with predefined point A and point B
         SYSTEMID    = 25,
         AUTOROTATE  = 26,
         AUTO_RTL    = 27,
         TURTLE      = 28,
-        OPTICAL_FLOW = 22, // This is the stock "FLOWHOLD" mode which is essentially unused in EchoMAV ArduPilot
+        OPTICAL_FLOW = 99, // This truly points to stock "FLOWHOLD" in EchoMAV ArduPilot
     };
 
     APMCopterMode(uint32_t mode, bool settable);

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -42,14 +42,14 @@ public:
         AVOID_ADSB  = 19,
         GUIDED_NOGPS= 20,
         SMART_RTL   = 21,  // SMART_RTL returns to home by retracing its steps
-        FLOWHOLD    = 22,  // FLOWHOLD holds position with optical flow without rangefinder
+        FLOWHOLD    = 99,  // This truly points to EchoMAV "Optical Flow" mode and not stock "FLOWHOLD" mode
         FOLLOW      = 23,  // follow attempts to follow another vehicle or ground station
         ZIGZAG      = 24,  // ZIGZAG mode is able to fly in a zigzag manner with predefined point A and point B
         SYSTEMID    = 25,
         AUTOROTATE  = 26,
         AUTO_RTL    = 27,
         TURTLE      = 28,
-        OPTICAL_FLOW = 99,
+        OPTICAL_FLOW = 22, // This is the stock "FLOWHOLD" mode which is essentially unused in EchoMAV ArduPilot
     };
 
     APMCopterMode(uint32_t mode, bool settable);

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -16,7 +16,7 @@
  *
  */
 
-#define ECHOMAV_VERSION "v1.0.5"
+#define ECHOMAV_VERSION "v1.0.6"
 
 #include <QFile>
 #include <QRegularExpression>


### PR DESCRIPTION
In EchoMAV ardupilot mode 22 (FLOWHOLD) and 99 (OPTICAL_FLOW) are reversed. Therefore in the QGC we want to show FLOWHOLD to the pilot even tho in ardupilot it triggers OPTICAL_FLOW. This will keep it consistent for ATAK integration.